### PR TITLE
SG-41525 Replace lambda with functools.partial in get_actions_for_publishes.py 

### DIFF
--- a/python/tk_multi_entity_app/loader_action_manager.py
+++ b/python/tk_multi_entity_app/loader_action_manager.py
@@ -8,9 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import functools
 import os
 import sys
-from functools import partial
 
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
@@ -101,7 +101,9 @@ class LoaderActionManager(ActionManager):
             ]
 
             # Bind all the action params to a single invocation of the _execute_hook.
-            handler = partial(self._execute_hook, qt_action=a, actions=actions)
+            handler = functools.partial(
+                self._execute_hook, qt_action=a, actions=actions
+            )
             a.triggered[()].connect(handler)
 
             a.setData(actions)

--- a/python/tk_multi_entity_app/loader_action_manager.py
+++ b/python/tk_multi_entity_app/loader_action_manager.py
@@ -8,9 +8,11 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import sgtk
 import os
 import sys
+from functools import partial
+
+import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 from sgtk.util import login
 
@@ -99,11 +101,9 @@ class LoaderActionManager(ActionManager):
             ]
 
             # Bind all the action params to a single invocation of the _execute_hook.
-            a.triggered[()].connect(
-                lambda qt_action=a, actions=actions: self._execute_hook(
-                    qt_action, actions
-                )
-            )
+            handler = partial(self._execute_hook, qt_action=a, actions=actions)
+            a.triggered[()].connect(handler)
+
             a.setData(actions)
             qt_actions.append(a)
 

--- a/python/tk_multi_entity_app/loader_action_manager.py
+++ b/python/tk_multi_entity_app/loader_action_manager.py
@@ -101,10 +101,9 @@ class LoaderActionManager(ActionManager):
             ]
 
             # Bind all the action params to a single invocation of the _execute_hook.
-            handler = functools.partial(
-                self._execute_hook, qt_action=a, actions=actions
+            a.triggered[()].connect(
+                functools.partial(self._execute_hook, qt_action=a, actions=actions)
             )
-            a.triggered[()].connect(handler)
 
             a.setData(actions)
             qt_actions.append(a)


### PR DESCRIPTION
### **Description**
This pull request makes minor improvements to the `loader_action_manager.py` file, focusing on code clarity and maintainability. The most notable change is the use of `functools.partial` to simplify the signal handler connection for action triggers.

Code quality and maintainability:

* Replaced the lambda function with `functools.partial` when connecting the `triggered` signal to `_execute_hook`, making the code more readable and less error-prone.
* Moved the `import sgtk` statement to follow standard import order and added the import for `functools.partial`.

This is a replica from shotgunsoftware/tk-multi-loader2#131